### PR TITLE
Specify plugin directory and driver name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,24 +34,26 @@ The "infoblox-ipam" driver accept a number of arguments which can be listed by s
 ```
 ubuntu$ ./infoblox-ipam --help
 Usage of ./infoblox-ipam:
-  -cidr string
-        Default Network CIDR if --subnet is not specified during docker network create (default "10.2.1.0/24")
+  -default-cidr string
+    			Default Network CIDR if --subnet is not specified during docker network create (default "10.2.1.0/24")
+  -driver-name string
+    		   Name of Infoblox IPAM driver (default "mddi")
   -global-view string
-        Infoblox Network View for Global Address Space (default "default")
+    		   Infoblox Network View for Global Address Space (default "default")
   -grid-host string
-        IP of Infoblox Grid Host (default "192.168.124.200")
+    		 IP of Infoblox Grid Host (default "192.168.124.200")
   -local-view string
-        Infoblox Network View for Local Address Space (default "default")
-  -socket string
-        Unix socket for infoblox-ipam driver (default "/run/docker/plugins/mddi.sock")
+    		  Infoblox Network View for Local Address Space (default "default")
+  -plugin-dir string
+    		  Docker plugin directory where driver socket is created (default "/run/docker/plugins")
   -wapi-password string
-        Infoblox WAPI Password
+    			 Infoblox WAPI Password
   -wapi-port string
-        Infoblox WAPI Port. (default "443")
+    		 Infoblox WAPI Port. (default "443")
   -wapi-username string
-        Infoblox WAPI Username
-  -wapi-ver string
-        Infoblox WAPI Version. (default "2.2")
+    			 Infoblox WAPI Username
+  -wapi-version string
+    			Infoblox WAPI Version. (default "2.2")
 ```
 
 For example,

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-DRIVER_NAME=mddi
-IMAGE_NAME=infoblox-ipam
+DOCKER_IMAGE="infoblox/ipam-driver"
+DRIVER_NAME="mddi"
+PLUGIN_DIR="/run/docker/plugins"
+GRID_HOST="192.168.124.200"
+WAPI_PORT="443"
+WAPI_USERNAME=""
+WAPI_PASSWORD=""
+WAPI_VERSION="2.2"
+GLOBAL_VIEW="default"
+LOCAL_VIEW="default"
+DEFAULT_CIDR="10.2.1.0/24"
 
-DEFAULT_CIDR=111.0.0.0/24
 
-SOCK_EXT=sock
-PLUGIN_DIR=/run/docker/plugins
-
+SOCK_EXT="sock"
 DRIVER_SOCKET=${PLUGIN_DIR}/${DRIVER_NAME}.${SOCK_EXT}
 
-rm -f $DRIVER_SOCKET
 
-docker run -v /var/run:/var/run -v /run/docker:/run/docker infoblox-ipam --grid-host=192.168.124.200 --wapi-port=443 --wapi-username=cloudadmin --wapi-password=cloudadmin --global-view=global_view --local-view=local_view --cidr=$DEFAULT_CIDR --socket=$DRIVER_SOCKET
+docker run  -v /var/run:/var/run -v /run/docker:/run/docker ${DOCKER_IMAGE} --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --global-view=${GLOBAL_VIEW} --local-view=${LOCAL_VIEW} --default-cidr=${DEFAULT_CIDR} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}

--- a/run.sh
+++ b/run.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
-DRIVER_NAME=mddi
+DRIVER_NAME="mddi"
+PLUGIN_DIR="/run/docker/plugins"
+GRID_HOST="192.168.124.200"
+WAPI_PORT="443"
+WAPI_USERNAME=""
+WAPI_PASSWORD=""
+WAPI_VERSION="2.2"
+GLOBAL_VIEW="default"
+LOCAL_VIEW="default"
+DEFAULT_CIDR="10.2.1.0/24"
 
-DEFAULT_CIDR=111.0.0.0/24
 
-SOCK_EXT=sock
-PLUGIN_DIR=/run/docker/plugins
-
+SOCK_EXT="sock"
 DRIVER_SOCKET=${PLUGIN_DIR}/${DRIVER_NAME}.${SOCK_EXT}
 
-rm -f $DRIVER_SOCKET
 
-./infoblox-ipam --grid-host=192.168.124.200 --wapi-port=443 --wapi-username=cloudadmin --wapi-password=cloudadmin --global-view=global_view --local-view=local_view --cidr=$DEFAULT_CIDR --socket=$DRIVER_SOCKET
+./infoblox-ipam --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --global-view=${GLOBAL_VIEW} --local-view=${LOCAL_VIEW} --default-cidr=${DEFAULT_CIDR} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}


### PR DESCRIPTION
Added IPAM driver command line options to specify
plugin directory as well as driver name.
The driver also takes care of creating plugin directory if
necessary. It also makes sure old driver socket file is
deleted if one exists.
