### PR TITLE
Add Network Container Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,32 +35,38 @@ ipam-driver accepts a number of arguments which can be listed by specifying -h:
 ```
 ubuntu$ ./ipam-driver --help
 Usage of ./ipam-driver:
-  -default-cidr string
-    	Default Network CIDR if --subnet is not specified during docker network create (default "10.2.1.0/24")
   -driver-name string
-    	Name of Infoblox IPAM driver (default "mddi")
+        Name of Infoblox IPAM driver (default "mddi")
+  -global-network-container string
+        Subnets will be allocated from this container when --subnet is not specified during network creation (default "172.18.0.0/16")
+  -global-prefix-length uint
+        The default CIDR prefix length when allocating a global subnet. (default 24)
   -global-view string
-    	Infoblox Network View for Global Address Space (default "default")
+        Infoblox Network View for Global Address Space (default "default")
   -grid-host string
-    	IP of Infoblox Grid Host (default "192.168.124.200")
+        IP of Infoblox Grid Host (default "192.168.124.200")
+  -local-network-container string
+        Subnets will be allocated from this container when --subnet is not specified during network creation (default "192.168.0.0/16")
+  -local-prefix-length uint
+        The default CIDR prefix length when allocating a local subnet. (default 24)
   -local-view string
-    	Infoblox Network View for Local Address Space (default "default")
+        Infoblox Network View for Local Address Space (default "default")
   -plugin-dir string
-    	Docker plugin directory where driver socket is created (default "/run/docker/plugins")
+        Docker plugin directory where driver socket is created (default "/run/docker/plugins")
   -wapi-password string
-    	Infoblox WAPI Password
+        Infoblox WAPI Password
   -wapi-port string
-    	Infoblox WAPI Port. (default "443")
+        Infoblox WAPI Port. (default "443")
   -wapi-username string
-    	Infoblox WAPI Username
+        Infoblox WAPI Username
   -wapi-version string
-    	Infoblox WAPI Version. (default "2.0")
+        Infoblox WAPI Version. (default "2.0")
 ```
 
 For example,
 
 ```
-./ipam-driver --grid-host=192.168.124.200 --wapi-username=cloudadmin --wapi-password=cloudadmin --global-view=global_view
+./ipam-driver --grid-host=192.168.124.200 --wapi-username=cloudadmin --wapi-password=cloudadmin --local-view=global_view --local-network-container="192.168.0.0/24,192.169.0.0/24" --local-prefix-length=24
 ```
 The command need to be executed with root permission.
 
@@ -93,7 +99,15 @@ To start using the dirver, a docker network needs to be created specifying the d
 sudo docker network create --ipam-driver=mddi mddi-net
 ```
 This creates a docker network called "mddi-net" which uses "mddi" as the IPAM driver and the default "bridge"
-driver as the network driver.
+driver as the network driver. A network will be automatically allocated from the list of network containers
+specified during driver start up.
+
+By default, the network will be created using the default prefix length specified during driver start up. You
+can override this using the --ipam-opt option. For example:
+
+```
+sudo docker network create --ipam-driver=mddi --ipam-opt="prefix-length=20" mddi-net-2
+```
 
 After which, Docker containers can be started attaching to the "mddi-net" network created above. For example,
 the following command run the "ubuntu" image:

--- a/infoblox-ipam.go
+++ b/infoblox-ipam.go
@@ -1,18 +1,39 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	ipamsapi "github.com/docker/libnetwork/ipams/remote/api"
 	netlabel "github.com/docker/libnetwork/netlabel"
 	ibclient "github.com/infobloxopen/infoblox-go-client"
 	"log"
+	"strconv"
+	"strings"
+)
+
+type Container struct {
+	NetworkContainer string // CIDR of Network Container
+	ContainerObj     *ibclient.NetworkContainer
+	exhausted        bool
+}
+
+type InfobloxAddressSpace struct {
+	NetviewName  string // Network View Name
+	PrefixLength uint   // Prefix Length
+	Containers   []Container
+}
+
+type AddressSpaceScope int
+
+const (
+	GLOBAL AddressSpaceScope = iota
+	LOCAL
 )
 
 type InfobloxDriver struct {
-	objMgr      *ibclient.ObjectManager
-	globalNetview string
-	localNetview string
-	defaultPool string
+	objMgr              *ibclient.ObjectManager
+	addressSpaceByScope map[AddressSpaceScope]*InfobloxAddressSpace
+	addressSpaceByView  map[string]*InfobloxAddressSpace
 }
 
 func (ibDrv *InfobloxDriver) PluginActivate(r interface{}) (map[string]interface{}, error) {
@@ -27,9 +48,16 @@ func (ibDrv *InfobloxDriver) GetCapabilities(r interface{}) (map[string]interfac
 }
 
 func (ibDrv *InfobloxDriver) GetDefaultAddressSpaces(r interface{}) (map[string]interface{}, error) {
-	globalViewRef, localViewRef := ibDrv.objMgr.CreateDefaultNetviews(ibDrv.globalNetview, ibDrv.localNetview)
+	globalViewRef, localViewRef := ibDrv.objMgr.CreateDefaultNetviews(
+		ibDrv.addressSpaceByScope[GLOBAL].NetviewName,
+		ibDrv.addressSpaceByScope[LOCAL].NetviewName)
 
 	return map[string]interface{}{"GlobalDefaultAddressSpace": globalViewRef, "LocalDefaultAddressSpace": localViewRef}, nil
+}
+
+func getPrefixLength(cidr string) (prefixLength string) {
+	parts := strings.Split(cidr, "/")
+	return parts[1]
 }
 
 func (ibDrv *InfobloxDriver) RequestAddress(r interface{}) (map[string]interface{}, error) {
@@ -42,12 +70,12 @@ func (ibDrv *InfobloxDriver) RequestAddress(r interface{}) (map[string]interface
 	network := ibclient.BuildNetworkFromRef(v.PoolID)
 	fixedAddr, _ := ibDrv.objMgr.AllocateIP(network.NetviewName, network.Cidr, macAddr)
 
-	return map[string]interface{}{"Address": fmt.Sprintf("%s/24", fixedAddr.IPAddress)}, nil
+	return map[string]interface{}{"Address": fmt.Sprintf("%s/%s", fixedAddr.IPAddress, getPrefixLength(network.Cidr))}, nil
 }
 
 func (ibDrv *InfobloxDriver) ReleaseAddress(r interface{}) (map[string]interface{}, error) {
 	v := r.(*ipamsapi.ReleaseAddressRequest)
-
+	log.Printf("Releasing Address '%s' from Pool '%s'\n", v.Address, v.PoolID)
 	network := ibclient.BuildNetworkFromRef(v.PoolID)
 	ref, _ := ibDrv.objMgr.ReleaseIP(network.NetviewName, v.Address)
 	if ref == "" {
@@ -57,28 +85,110 @@ func (ibDrv *InfobloxDriver) ReleaseAddress(r interface{}) (map[string]interface
 	return map[string]interface{}{}, nil
 }
 
-func (ibDrv *InfobloxDriver) RequestPool(r interface{}) (map[string]interface{}, error) {
-	v := r.(*ipamsapi.RequestPoolRequest)
-
-	pool := ibDrv.defaultPool
-	if len(v.Pool) > 0 {
-		pool = v.Pool
-	}
-	netview := ibclient.BuildNetworkViewFromRef(v.AddressSpace).Name
-
-	network, _ := ibDrv.objMgr.GetNetwork(netview, pool)
+func (ibDrv *InfobloxDriver) requestSpecificNetwork(netview string, pool string) (*ibclient.Network, error) {
+	network, err := ibDrv.objMgr.GetNetwork(netview, pool)
 	if network == nil {
-		network, _ = ibDrv.objMgr.CreateNetwork(netview, pool)
+		network, err = ibDrv.objMgr.CreateNetwork(netview, pool)
 	}
 
-	return map[string]interface{}{"PoolID": network.Ref, "Pool": network.Cidr}, nil
+	return network, err
+}
+
+func (ibDrv *InfobloxDriver) createNetworkContainer(netview string, pool string) (*ibclient.NetworkContainer, error) {
+	container, err := ibDrv.objMgr.GetNetworkContainer(netview, pool)
+	if container == nil {
+		container, err = ibDrv.objMgr.CreateNetworkContainer(netview, pool)
+	}
+
+	return container, err
+}
+
+func nextAvailableContainer(addrSpace *InfobloxAddressSpace) *Container {
+	for i, _ := range addrSpace.Containers {
+		if !addrSpace.Containers[i].exhausted {
+			return &addrSpace.Containers[i]
+		}
+	}
+
+	return nil
+}
+
+func resetContainers(addrSpace *InfobloxAddressSpace) {
+	for i, _ := range addrSpace.Containers {
+		addrSpace.Containers[i].exhausted = false
+	}
+}
+
+func (ibDrv *InfobloxDriver) allocateNetworkHelper(addrSpace *InfobloxAddressSpace, prefixLen uint) (network *ibclient.Network, err error) {
+	if prefixLen == 0 {
+		prefixLen = addrSpace.PrefixLength
+	}
+	container := nextAvailableContainer(addrSpace)
+	for container != nil {
+		log.Printf("Allocating network from Container:'%s'", container.NetworkContainer)
+		if container.ContainerObj == nil {
+			var err error
+			container.ContainerObj, err = ibDrv.createNetworkContainer(addrSpace.NetviewName, container.NetworkContainer)
+			if err != nil {
+				return nil, err
+			}
+		}
+		network, err = ibDrv.objMgr.AllocateNetwork(addrSpace.NetviewName, container.NetworkContainer, prefixLen)
+		if network != nil {
+			break
+		}
+		container.exhausted = true
+		container = nextAvailableContainer(addrSpace)
+	}
+
+	return network, nil
+}
+
+func (ibDrv *InfobloxDriver) allocateNetwork(netview string, prefixLen uint) (network *ibclient.Network, err error) {
+	addrSpace := ibDrv.addressSpaceByView[netview]
+
+	network, err = ibDrv.allocateNetworkHelper(addrSpace, prefixLen)
+	if network == nil {
+		resetContainers(addrSpace)
+		network, err = ibDrv.allocateNetworkHelper(addrSpace, prefixLen)
+	}
+
+	if network == nil {
+		err = errors.New("Cannot allocate network in Address Space")
+	}
+	return
+}
+
+func (ibDrv *InfobloxDriver) RequestPool(r interface{}) (res map[string]interface{}, err error) {
+	v := r.(*ipamsapi.RequestPoolRequest)
+	log.Printf("RequestPoolRequest is '%v'\n", v)
+
+	netviewName := ibclient.BuildNetworkViewFromRef(v.AddressSpace).Name
+
+	var network *ibclient.Network
+	if len(v.Pool) > 0 {
+		network, err = ibDrv.requestSpecificNetwork(netviewName, v.Pool)
+	} else {
+		var prefixLen uint
+		if opt, ok := v.Options["prefix-length"]; ok {
+			if v, err := strconv.ParseUint(opt, 10, 8); err == nil {
+				prefixLen = uint(v)
+			}
+		}
+		network, err = ibDrv.allocateNetwork(netviewName, prefixLen)
+	}
+
+	if network != nil {
+		res = map[string]interface{}{"PoolID": network.Ref, "Pool": network.Cidr}
+	}
+	return res, err
 }
 
 func (ibDrv *InfobloxDriver) ReleasePool(r interface{}) (map[string]interface{}, error) {
 	v := r.(*ipamsapi.ReleasePoolRequest)
 
 	if len(v.PoolID) > 0 {
-		ref, _ := ibDrv.objMgr.DeleteLocalNetwork(v.PoolID, ibDrv.localNetview)
+		ref, _ := ibDrv.objMgr.DeleteLocalNetwork(v.PoolID, ibDrv.addressSpaceByScope[LOCAL].NetviewName)
 		if len(ref) > 0 {
 			log.Printf("Network %s deleted from Infoblox\n", v.PoolID)
 		}
@@ -87,8 +197,38 @@ func (ibDrv *InfobloxDriver) ReleasePool(r interface{}) (map[string]interface{},
 	return map[string]interface{}{}, nil
 }
 
-func NewInfobloxDriver(objMgr *ibclient.ObjectManager, globalNetview string, 
-	localNetview string, defaultPool string) *InfobloxDriver {
-	return &InfobloxDriver{objMgr: objMgr, globalNetview: globalNetview,
-		localNetview: localNetview, defaultPool: defaultPool}
+func makeContainers(containerList string) []Container {
+	containers := make([]Container, 0)
+
+	parts := strings.Split(containerList, ",")
+	for _, p := range parts {
+		containers = append(containers, Container{p, nil, false})
+	}
+
+	return containers
+}
+
+func NewInfobloxDriver(objMgr *ibclient.ObjectManager,
+	globalNetview string, globalNetworkContainer string, globalPrefixLength uint,
+	localNetview string, localNetworkContainer string, localPrefixLength uint) *InfobloxDriver {
+
+	globalContainers := makeContainers(globalNetworkContainer)
+	localContainers := makeContainers(localNetworkContainer)
+
+	globalAddressSpace := &InfobloxAddressSpace{
+		globalNetview, globalPrefixLength, globalContainers}
+	localAddressSpace := &InfobloxAddressSpace{
+		localNetview, localPrefixLength, localContainers}
+
+	return &InfobloxDriver{
+		objMgr: objMgr,
+		addressSpaceByScope: map[AddressSpaceScope]*InfobloxAddressSpace{
+			GLOBAL: globalAddressSpace,
+			LOCAL:  localAddressSpace,
+		},
+		addressSpaceByView: map[string]*InfobloxAddressSpace{
+			globalNetview: globalAddressSpace,
+			localNetview:  localAddressSpace,
+		},
+	}
 }

--- a/run-container.sh
+++ b/run-container.sh
@@ -9,8 +9,11 @@ WAPI_USERNAME=""
 WAPI_PASSWORD=""
 WAPI_VERSION="2.0"
 GLOBAL_VIEW="default"
+GLOBAL_CONTAINER="172.18.0.0/16"
+GLOBAL_PREFIX=24
 LOCAL_VIEW="default"
-DEFAULT_CIDR="10.2.1.0/24"
+LOCAL_CONTAINER="192.168.0.0/16"
+LOCAL_PREFIX=24
 
 
-docker run  -v /var/run:/var/run -v /run/docker:/run/docker ${DOCKER_IMAGE} --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --global-view=${GLOBAL_VIEW} --local-view=${LOCAL_VIEW} --default-cidr=${DEFAULT_CIDR} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}
+docker run  -v /var/run:/var/run -v /run/docker:/run/docker ${DOCKER_IMAGE} --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --global-view=${GLOBAL_VIEW} --global-network-container=${GLOBAL_CONTAINER} --global-prefix-length=${GLOBAL_PREFIX} --local-view=${LOCAL_VIEW} --local-network-container=${LOCAL_CONTAINER} --local-prefix-length=${LOCAL_PREFIX} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}

--- a/run.sh
+++ b/run.sh
@@ -8,8 +8,12 @@ WAPI_USERNAME=""
 WAPI_PASSWORD=""
 WAPI_VERSION="2.0"
 GLOBAL_VIEW="default"
+GLOBAL_CONTAINER="172.18.0.0/16"
+GLOBAL_PREFIX=24
 LOCAL_VIEW="default"
-DEFAULT_CIDR="10.2.1.0/24"
+LOCAL_CONTAINER="192.168.0.0/16"
+LOCAL_PREFIX=24
 
 
-./ipam-driver --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --global-view=${GLOBAL_VIEW} --local-view=${LOCAL_VIEW} --default-cidr=${DEFAULT_CIDR} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}
+
+./ipam-driver --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --global-view=${GLOBAL_VIEW} --global-network-container=${GLOBAL_CONTAINER} --global-prefix-length=${GLOBAL_PREFIX} --local-view=${LOCAL_VIEW} --local-network-container=${LOCAL_CONTAINER} --local-prefix-length=${LOCAL_PREFIX} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}


### PR DESCRIPTION
Network containers for Global and Local Address Spaces can be specified
during driver start up.

A comma separated list of network containers can be specified for each
address space.
Networks will allocated from the list of network containers until
they are all exhausted.

During network creation, if no subnet is specified, a network will be
allocated automatically from the next available network container.

Additionally, during network creation, a prefix length can be specified
via --ipam-opt to overide the default prefix length for the address space.
For example:

--ipam-opt="prefix-length=25"
