### PR TITLE
Add SSL verify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Usage of ./ipam-driver:
         Infoblox Network View for Local Address Space (default "default")
   -plugin-dir string
         Docker plugin directory where driver socket is created (default "/run/docker/plugins")
+  -ssl-verify string
+        Specifies whether (true/false) to verify server certificate. If a file path is specified, it is assumed to be a certificate file and will be used to verify server certificate.
   -wapi-password string
         Infoblox WAPI Password
   -wapi-port string

--- a/infoblox-ipam.go
+++ b/infoblox-ipam.go
@@ -48,11 +48,11 @@ func (ibDrv *InfobloxDriver) GetCapabilities(r interface{}) (map[string]interfac
 }
 
 func (ibDrv *InfobloxDriver) GetDefaultAddressSpaces(r interface{}) (map[string]interface{}, error) {
-	globalViewRef, localViewRef := ibDrv.objMgr.CreateDefaultNetviews(
+	globalViewRef, localViewRef, err := ibDrv.objMgr.CreateDefaultNetviews(
 		ibDrv.addressSpaceByScope[GLOBAL].NetviewName,
 		ibDrv.addressSpaceByScope[LOCAL].NetviewName)
 
-	return map[string]interface{}{"GlobalDefaultAddressSpace": globalViewRef, "LocalDefaultAddressSpace": localViewRef}, nil
+	return map[string]interface{}{"GlobalDefaultAddressSpace": globalViewRef, "LocalDefaultAddressSpace": localViewRef}, err
 }
 
 func getPrefixLength(cidr string) (prefixLength string) {

--- a/run-container.sh
+++ b/run-container.sh
@@ -8,6 +8,7 @@ WAPI_PORT="443"
 WAPI_USERNAME=""
 WAPI_PASSWORD=""
 WAPI_VERSION="2.0"
+SSL_VERIFY="false"
 GLOBAL_VIEW="default"
 GLOBAL_CONTAINER="172.18.0.0/16"
 GLOBAL_PREFIX=24
@@ -16,4 +17,4 @@ LOCAL_CONTAINER="192.168.0.0/16"
 LOCAL_PREFIX=24
 
 
-docker run  -v /var/run:/var/run -v /run/docker:/run/docker ${DOCKER_IMAGE} --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --global-view=${GLOBAL_VIEW} --global-network-container=${GLOBAL_CONTAINER} --global-prefix-length=${GLOBAL_PREFIX} --local-view=${LOCAL_VIEW} --local-network-container=${LOCAL_CONTAINER} --local-prefix-length=${LOCAL_PREFIX} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}
+docker run  -v /var/run:/var/run -v /run/docker:/run/docker ${DOCKER_IMAGE} --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --ssl-verify=${SSL_VERIFY} --global-view=${GLOBAL_VIEW} --global-network-container=${GLOBAL_CONTAINER} --global-prefix-length=${GLOBAL_PREFIX} --local-view=${LOCAL_VIEW} --local-network-container=${LOCAL_CONTAINER} --local-prefix-length=${LOCAL_PREFIX} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ WAPI_PORT="443"
 WAPI_USERNAME=""
 WAPI_PASSWORD=""
 WAPI_VERSION="2.0"
+SSL_VERIFY="false"
 GLOBAL_VIEW="default"
 GLOBAL_CONTAINER="172.18.0.0/16"
 GLOBAL_PREFIX=24
@@ -16,4 +17,4 @@ LOCAL_PREFIX=24
 
 
 
-./ipam-driver --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --global-view=${GLOBAL_VIEW} --global-network-container=${GLOBAL_CONTAINER} --global-prefix-length=${GLOBAL_PREFIX} --local-view=${LOCAL_VIEW} --local-network-container=${LOCAL_CONTAINER} --local-prefix-length=${LOCAL_PREFIX} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}
+./ipam-driver --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --ssl-verify=${SSL_VERIFY} --global-view=${GLOBAL_VIEW} --global-network-container=${GLOBAL_CONTAINER} --global-prefix-length=${GLOBAL_PREFIX} --local-view=${LOCAL_VIEW} --local-network-container=${LOCAL_CONTAINER} --local-prefix-length=${LOCAL_PREFIX} --plugin-dir=${PLUGIN_DIR} --driver-name=${DRIVER_NAME}


### PR DESCRIPTION
Added --ssl-verify cli option for the IPAM driver, which allows a user
to specify whether to enforce SSL certificate verification for the
connection to Infoblox. The default is false.

Alternatively, the name of a cerficate file in PEM format can be specified,
in whcih case, the certificate will be used to verify the Infoblox
certificate.

Minor refactoring to better handle SSL certificate verification error.
