### PR TITLE
Add create_ea_defs tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,12 @@ LOCAL_IMAGE=$(IMAGE_NAME)
 DEV_IMAGE=$(DOCKERHUB_ID)/$(IMAGE_NAME)  # Requires DOCKERHUB_ID environment variable
 RELEASE_IMAGE=infoblox/$(IMAGE_NAME)
 
+CREATE_EA_DEFS=create_ea_defs
+CREATE_EA_DEFS_SOURCES=create_ea_defs.go config.go constants.go
+
 
 # Build binary - this is the default target
-build: $(BINARY_NAME)
+build: $(BINARY_NAME) $(CREATE_EA_DEFS)
 
 
 # Build binary and docker image
@@ -28,12 +31,15 @@ push-release: image
 	docker tag $(LOCAL_IMAGE) $(RELEASE_IMAGE)
 	docker push $(RELEASE_IMAGE)
 
-$(BINARY_NAME): *.go
+$(BINARY_NAME): $(SOURCES)
 	go build -o $(BINARY_NAME) ${SOURCES}
+
+$(CREATE_EA_DEFS): $(CREATE_EA_DEFS_SOURCES)
+	go build -o $(CREATE_EA_DEFS) ${CREATE_EA_DEFS_SOURCES}
 
 # Delete binary for clean build
 clean:
-	rm -f $(BINARY_NAME)
+	rm -f $(BINARY_NAME) $(CREATE_EA_DEFS)
 
 # Delete local docker images
 clean-images:

--- a/config.go
+++ b/config.go
@@ -4,13 +4,22 @@ import (
 	"flag"
 )
 
+const (
+	HTTP_REQUEST_TIMEOUT  = 120
+	HTTP_POOL_CONNECTIONS = 100
+	HTTP_POOL_MAX_SIZE    = 100
+)
+
 type GridConfig struct {
-	GridHost     string
-	WapiVer      string
-	WapiPort     string
-	WapiUsername string
-	WapiPassword string
-	SslVerify    string
+	GridHost            string
+	WapiVer             string
+	WapiPort            string
+	WapiUsername        string
+	WapiPassword        string
+	SslVerify           string
+	HttpRequestTimeout  int
+	HttpPoolConnections int
+	HttpPoolMaxSize     int
 }
 
 type DriverConfig struct {
@@ -38,6 +47,10 @@ func LoadConfig() (config *Config) {
 	flag.StringVar(&config.WapiUsername, "wapi-username", "", "Infoblox WAPI Username")
 	flag.StringVar(&config.WapiPassword, "wapi-password", "", "Infoblox WAPI Password")
 	flag.StringVar(&config.SslVerify, "ssl-verify", "false", "Specifies whether (true/false) to verify server certificate. If a file path is specified, it is assumed to be a certificate file and will be used to verify server certificate.")
+	config.HttpRequestTimeout = HTTP_REQUEST_TIMEOUT
+	config.HttpPoolConnections = HTTP_POOL_CONNECTIONS
+	config.HttpPoolMaxSize = HTTP_POOL_MAX_SIZE
+
 	flag.StringVar(&config.PluginDir, "plugin-dir", "/run/docker/plugins", "Docker plugin directory where driver socket is created")
 	flag.StringVar(&config.DriverName, "driver-name", "mddi", "Name of Infoblox IPAM driver")
 	flag.StringVar(&config.GlobalNetview, "global-view", "default", "Infoblox Network View for Global Address Space")

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	ibclient "github.com/infobloxopen/infoblox-go-client"
+)
+
+const (
+	EA_GRID_CONFIG_GRID_SYNC_SUPPORT           = "Grid Sync Support"
+	EA_GRID_CONFIG_GRID_SYNC_MINIMUM_WAIT_TIME = "Grid Sync Minimum Wait Time"
+	EA_GRID_CONFIG_GRID_SYNC_MAXIMUM_WAIT_TIME = "Grid Sync Maximum Wait Time"
+	EA_GRID_CONFIG_DEFAULT_NETWORK_VIEW_SCOPE  = "Default Network View Scope"
+	EA_GRID_CONFIG_DEFAULT_NETWORK_VIEW        = "Default Network View"
+	EA_GRID_CONFIG_DEFAULT_HOST_NAME_PATTERN   = "Default Host Name Pattern"
+	EA_GRID_CONFIG_DEFAULT_DOMAIN_NAME_PATTERN = "Default Domain Name Pattern"
+	EA_GRID_CONFIG_NS_GROUP                    = "NS Group"
+	EA_GRID_CONFIG_DNS_VIEW                    = "DNS View"
+	EA_GRID_CONFIG_NETWORK_TEMPLATE            = "Network Template"
+	EA_GRID_CONFIG_ADMIN_NETWORK_DELETION      = "Admin Network Deletion"
+	EA_GRID_CONFIG_IP_ALLOCATION_STRATEGY      = "IP Allocation Strategy"
+	EA_GRID_CONFIG_DNS_RECORD_BINDING_TYPES    = "DNS Record Binding Types"
+	EA_GRID_CONFIG_DNS_RECORD_UNBINDING_TYPES  = "DNS Record Unbinding Types"
+	EA_GRID_CONFIG_DNS_RECORD_REMOVABLE_TYPES  = "DNS Record Removable Types"
+	EA_GRID_CONFIG_DHCP_SUPPORT                = "DHCP Support"
+	EA_GRID_CONFIG_DNS_SUPPORT                 = "DNS Support"
+	EA_GRID_CONFIG_RELAY_SUPPORT               = "Relay Support"
+	EA_GRID_CONFIG_USE_GM_FOR_DHCP             = "Use Grid Master for DHCP"
+	EA_GRID_CONFIG_TENANT_NAME_PERSISTENCE     = "Tenant Name Persistence"
+	EA_GRID_CONFIG_REPORT_GRID_SYNC_TIME       = "Report Grid Sync Time"
+	EA_GRID_CONFIG_ALLOW_SERVICE_RESTART       = "Allow Service Restart"
+
+	EA_LAST_GRID_SYNC_TIME = "Last Grid Sync Time"
+
+	EA_MAPPING_ADDRESS_SCOPE_ID   = "Address Scope ID Mapping"
+	EA_MAPPING_ADDRESS_SCOPE_NAME = "Address Scope Name Mapping"
+	EA_MAPPING_TENANT_ID          = "Tenant ID Mapping"
+	EA_MAPPING_TENANT_NAME        = "Tenant Name Mapping"
+	EA_MAPPING_NETWORK_ID         = "Network ID Mapping"
+	EA_MAPPING_NETWORK_NAME       = "Network Name Mapping"
+	EA_MAPPING_SUBNET_ID          = "Subnet ID Mapping"
+	EA_MAPPING_SUBNET_CIDR        = "Subnet CIDR Mapping"
+
+	EA_CLOUD_ADAPTER_ID = "Cloud Adapter ID"
+	EA_IS_CLOUD_MEMBER  = "Is Cloud Member"
+
+	EA_SUBNET_ID             = "Subnet ID"
+	EA_SUBNET_NAME           = "Subnet Name"
+	EA_NETWORK_ID            = "Network ID"
+	EA_NETWORK_NAME          = "Network Name"
+	EA_NETWORK_ENCAP         = "Network Encap"
+	EA_SEGMENTATION_ID       = "Segmentation ID"
+	EA_PHYSICAL_NETWORK_NAME = "Physical Network Name"
+	EA_PORT_ID               = "Port ID"
+	EA_PORT_DEVICE_OWNER     = "Port Attached Device - Device Owner"
+	EA_PORT_DEVICE_ID        = "Port Attached Device - Device ID"
+	EA_VM_ID                 = "VM ID"
+	EA_VM_NAME               = "VM Name"
+	EA_IP_TYPE               = "IP Type"
+	EA_TENANT_ID             = "Tenant ID"
+	EA_TENANT_NAME           = "Tenant Name"
+	EA_ACCOUNT               = "Account"
+	EA_CLOUD_API_OWNED       = "Cloud API Owned"
+	EA_CMP_TYPE              = "CMP Type"
+	EA_IS_EXTERNAL           = "Is External"
+	EA_IS_SHARED             = "Is Shared"
+)
+
+const (
+	EA_TYPE_STRING  = "STRING"
+	EA_TYPE_ENUM    = "ENUM"
+	EA_TYPE_INTEGER = "INTEGER"
+)
+
+var RequiredEADefs = []ibclient.EADefinition{
+	{Name: EA_CLOUD_API_OWNED, Type: EA_TYPE_ENUM, Flags: "C",
+		ListValues: []ibclient.EADefListValue{"True", "False"},
+		Comment:    "Is Cloud API owned"},
+	{Name: EA_CMP_TYPE, Type: EA_TYPE_STRING, Flags: "C",
+		Comment: "CMP Types (Docker)"},
+	{Name: EA_TENANT_ID, Type: EA_TYPE_STRING, Flags: "C",
+		Comment: "Docker Engine ID"},
+	{Name: EA_VM_ID, Type: EA_TYPE_STRING, Flags: "C",
+		Comment: "Containter ID in Docker"},
+}
+
+func GetRequiredEADefs() []ibclient.EADefinition {
+	ea_defs := RequiredEADefs
+	res := make([]ibclient.EADefinition, len(ea_defs))
+	for i, d := range ea_defs {
+		res[i] = *ibclient.NewEADefinition(d)
+	}
+
+	return res
+}

--- a/create_ea_defs.go
+++ b/create_ea_defs.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	ibclient "github.com/infobloxopen/infoblox-go-client"
+	"log"
+)
+
+func main() {
+	config := LoadConfig()
+
+	conn, err := ibclient.NewConnector(
+		config.GridHost,
+		config.WapiVer,
+		config.WapiPort,
+		config.WapiUsername,
+		config.WapiPassword,
+		config.SslVerify,
+		config.HttpRequestTimeout,
+		config.HttpPoolConnections,
+		config.HttpPoolMaxSize)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	objMgr := ibclient.NewObjectManager(conn, "")
+
+	reqEaDefs := GetRequiredEADefs()
+	for _, e := range reqEaDefs {
+		eadef, err := objMgr.GetEADefinition(e.Name)
+
+		if err != nil {
+			log.Printf("GetEADefinition(%s) error '%s'", e.Name, err)
+			continue
+		}
+
+		if eadef != nil {
+			log.Printf("EA Definition '%s' already exists", eadef.Name)
+
+		} else {
+			log.Printf("EA Definition '%s' not found.", e.Name)
+			newEadef, err := objMgr.CreateEADefinition(e)
+			if err == nil {
+				log.Printf("EA Definition '%s' created", newEadef.Name)
+			}
+		}
+	}
+}

--- a/create_ea_defs.sh
+++ b/create_ea_defs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+PLUGIN_DIR="/run/docker/plugins"
+# GRID_HOST="192.168.124.200"
+GRID_HOST="192.168.124.200"
+WAPI_PORT="443"
+WAPI_USERNAME=""
+WAPI_PASSWORD=""
+WAPI_VERSION="2.2"
+SSL_VERIFY="false"
+
+
+
+./create_ea_defs --grid-host=${GRID_HOST} --wapi-port=${WAPI_PORT} --wapi-username=${WAPI_USERNAME} --wapi-password=${WAPI_PASSWORD} --wapi-version=${WAPI_VERSION} --ssl-verify=${SSL_VERIFY}

--- a/ipam-driver.go
+++ b/ipam-driver.go
@@ -153,9 +153,9 @@ func main() {
 		config.WapiUsername,
 		config.WapiPassword,
 		config.SslVerify,
-		120,
-		100,
-		100)
+		config.HttpRequestTimeout,
+		config.HttpPoolConnections,
+		config.HttpPoolMaxSize)
 
 	if err != nil {
 		log.Fatal(err)

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DOCKER_IMAGE="ipam-driver"
-DRIVER_NAME="mddi"
+DRIVER_NAME="infoblox"
 PLUGIN_DIR="/run/docker/plugins"
 GRID_HOST="192.168.124.200"
 WAPI_PORT="443"

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DRIVER_NAME="mddi"
+DRIVER_NAME="infoblox"
 PLUGIN_DIR="/run/docker/plugins"
 GRID_HOST="192.168.124.200"
 WAPI_PORT="443"


### PR DESCRIPTION
Added create_ea_defs tool which can be used at install time to
ensure all the required extensible attributes are defined in Infoblox. A
shell script wrapper is also included for convenience.

Various minor enhancements.
