### PR TITLE
Check Zero MAC

### DIFF
--- a/infoblox-ipam.go
+++ b/infoblox-ipam.go
@@ -75,6 +75,9 @@ func (ibDrv *InfobloxDriver) RequestAddress(r interface{}) (map[string]interface
 		fixedAddr, _ = ibDrv.objMgr.GetFixedAddress(network.NetviewName, v.Address, "")
 
 		if fixedAddr != nil {
+			if fixedAddr.Mac == "" {
+				fixedAddr.Mac = ibclient.MACADDR_ZERO
+			}
 			if fixedAddr.Mac != macAddr {
 				log.Printf("Requested IP address '%s' is already used by a difference MAC address '%s' (%s)",
 					v.Address, fixedAddr.Mac, macAddr)


### PR DESCRIPTION
When an NIOS Fixed Address is retrieved which has previous been set
to a MAC address of "00:00:00:00:00:00", the MAC address is actually
returned as "". Added code to account for this case.
