### PR TITLE
Revert "Use moby instead of deprecated docker engine-api (#30)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,3 @@ _testmain.go
 *.exe
 *.test
 *.prof
-
-# Ignore the binaries
-ipam-driver
-create_ea_defs

--- a/BUILD.md
+++ b/BUILD.md
@@ -13,10 +13,10 @@ following commands:
 
 ```
 go get github.com/docker/libnetwork  # libnetwork library (This also pulls down docker engine)
-go get github.com/moby/moby/client  # moby client library (NOTE: run "make deps" to get dependencies)
+go get github.com/docker/engine-api  # engine-api library (NOTE: run "make deps" to get dependencies)
 go get github.com/infobloxopen/infoblox-go-client  # Infoblox client
 ```
-```moby client``` is used by the infoblox-ipam driver to obtain the docker
+```engine-api``` is used by the infoblox-ipam driver to obtain the docker
 engine id, which is used to populate the "Tenant ID" EA.
 
 ```infoblox-go-client``` is used by the ipam-driver to interact

--- a/ipam-driver.go
+++ b/ipam-driver.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	apiclient "github.com/moby/moby/client"
+	apiclient "github.com/docker/engine-api/client"
 	ipamsapi "github.com/docker/libnetwork/ipams/remote/api"
 	ibclient "github.com/infobloxopen/infoblox-go-client"
 	ctx "golang.org/x/net/context"


### PR DESCRIPTION
This reverts commit b4eeff235258fa3a100fc79a310bd4640dba0bb0.
This is because of bug https://github.com/moby/moby/issues/33245