### PR TITLE
Update documentation and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build-binary:
 	docker rmi ipam-build-image
 
 .PHONY: build-plugin
-build-plugin:
+build-plugin: build-binary
 	docker build -t ${PLUGIN_NAME}:rootfs .
 	mkdir -p ./plugin/rootfs
 	docker create --name tmp ${PLUGIN_NAME}:rootfs
@@ -34,15 +34,15 @@ build-plugin:
 	docker rm -vf tmp
 
 .PHONY: create-plugin
-create-plugin: 
+create-plugin: clean-plugin build-plugin
 	docker plugin create ${PLUGIN_NAME}:${RELEASE} ./plugin
 
 .PHONY: enable-plugin
-enable-plugin:
+enable-plugin: create-plugin
 	docker plugin enable ${PLUGIN_NAME}:${RELEASE}
 
 .PHONY: push-plugin
-push-plugin:  clean-plugin build-binary build-plugin create-plugin
+push-plugin:  create-plugin
 	docker plugin push ${PLUGIN_NAME}:${RELEASE}
 
 .PHONY: clean-tools-image
@@ -51,10 +51,10 @@ clean-tools-image:
 	docker rmi ${TOOLS_IMAGE_NAME} || true
 
 .PHONY: build-tools-image
-build-tools-image:
+build-tools-image: clean-tools-image build-binary
 	docker build -t ${TOOLS_IMAGE_NAME} -f Dockerfile.tools .
 
 .PHONY: push-tools-image
-push-tools-image: clean-tools-image build-binary build-tools-image
+push-tools-image: build-tools-image
 	docker tag ${TOOLS_IMAGE_NAME} ${TOOLS_IMAGE_NAME}:${RELEASE}
 	docker push ${TOOLS_IMAGE_NAME}:${RELEASE}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Infoblox Docker IPAM Plugin
 
-Infoblox ipam-plugin is a Docker Engine managed plugin that interfaces with Infoblox
+Infoblox docker-ipam-plugin is a Docker Engine managed plugin that interfaces with Infoblox
 to provide IP Address Management services for Docker containers.
 
 ## Prerequisite
@@ -44,9 +44,9 @@ The configuration options are:
 
 ## Installation
 
-By default, the ipam-plugin assumes that the "Cloud Network Automation" licensed feature is activated in NIOS. Should this not be the case, refer to "Manual Configuration of Cloud Extensible Attributes" in CONFIG.md for additional configuration required.
+By default, the docker-ipam-plugin assumes that the "Cloud Network Automation" licensed feature is activated in NIOS. Should this not be the case, refer to "Manual Configuration of Cloud Extensible Attributes" in CONFIG.md for additional configuration required.
 
-Plugin is installed by pulling the infoblox/ipam-plugin from the docker store and setting its environment variables.
+Plugin is installed by pulling the infoblox/docker-ipam-plugin from the docker store and setting its environment variables.
 
 In Docker swarm mode the plugin needs to be installed on all the nodes.
 
@@ -81,10 +81,10 @@ local-prefix-length=25
 Set the CONF_FILE_NAME variable to this file name while installing the plugin.
 
 ```
-$ docker plugin install --alias infoblox infoblox/ipam-plugin:1.1.0 \
+$ docker plugin install --alias infoblox infoblox/docker-ipam-plugin:1.1.0 \
 CONF_FILE_NAME=docker-infoblox.conf
 
-Plugin "infoblox/ipam-plugin:1.1.0" is requesting the following privileges:
+Plugin "infoblox/docker-ipam-plugin:1.1.0" is requesting the following privileges:
  - network: [host]
  - mount: [/etc/infoblox]
  - mount: [/var/run]
@@ -101,7 +101,7 @@ To avoid the privileges request prompt pass the `--grant-all-permissions` option
 
 ```
 $ docker plugin install --grant-all-permissions --alias infoblox \
-infoblox/ipam-plugin:1.1.0 CONF_FILE_NAME=docker-infoblox.conf
+infoblox/docker-ipam-plugin:1.1.0 CONF_FILE_NAME=docker-infoblox.conf
 ```
 
 ### 2) Installing and configuring the plugin by setting its environment variables
@@ -109,7 +109,7 @@ infoblox/ipam-plugin:1.1.0 CONF_FILE_NAME=docker-infoblox.conf
 * Plugin can be configured without configuration file by setting all the plugin environment variables while installing the plugin.
 ```
 $ docker plugin install --grant-all-permissions --alias infoblox \
-infoblox/ipam-plugin:1.1.0 GRID_HOST=10.120.21.150 \
+infoblox/docker-ipam-plugin:1.1.0 GRID_HOST=10.120.21.150 \
 WAPI_USERNAME=admin WAPI_PASSWORD=infoblox GLOBAL_VIEW=global_view \
 GLOBAL_NETWORK_CONTAINER=172.18.0.0/16 LOCAL_VIEW=local_view \
 LOCAL_NETWORK_CONTAINER=192.168.0.0/20 LOCAL_PREFIX_LENGTH=25
@@ -118,7 +118,7 @@ LOCAL_NETWORK_CONTAINER=192.168.0.0/20 LOCAL_PREFIX_LENGTH=25
 * To override a configuration file option with the plugin environment variable
 ```
 $ docker plugin install --grant-all-permissions --alias infoblox \
-infoblox/ipam-plugin:1.1.0 CONF_FILE_NAME=docker-infoblox.conf \
+infoblox/docker-ipam-plugin:1.1.0 CONF_FILE_NAME=docker-infoblox.conf \
 LOCAL_NETWORK_CONTAINER=172.16.10.0/24
 ```
 Here `LOCAL_NETWORK_CONTAINER` overrides the `local-network-container` option in conf file.
@@ -126,7 +126,7 @@ Here `LOCAL_NETWORK_CONTAINER` overrides the `local-network-container` option in
 * Inorder to set the plugin log level as debug, set the `DEBUG` variable
 ```
 $ docker plugin install --grant-all-permissions --alias infoblox \
-infoblox/ipam-plugin:1.1.0 CONF_FILE_NAME=docker-infoblox.conf DEBUG=true
+infoblox/docker-ipam-plugin:1.1.0 CONF_FILE_NAME=docker-infoblox.conf DEBUG=true
 ```
 
 
@@ -186,7 +186,7 @@ Before performing the following steps, the plugin needs to be installed on all t
 
 1) Create a config only network on all the nodes
 ```
-sudo docker network create --config-only -o parent=eth1 --ipam-driver=infoblox/ipam-plugin:1.1.0 --ipam-opt="network-name=macvlan23" mv-config-3
+sudo docker network create --config-only -o parent=eth1 --ipam-driver=infoblox/docker-ipam-plugin:1.1.0 --ipam-opt="network-name=macvlan23" mv-config-3
 ```
 
 2) Create MACVLAN network with swarm scope on the swarm manager node

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -3,16 +3,16 @@ Building docker-ipam-plugin and docker-ipam-tools images
 
 Building Plugin Image
 ---------------------
-To build the plugin image use the following command:
+To create the plugin image use the following command:
 ```
-make build-binary build-plugin create-plugin
+make create-plugin
 ```
 
 Building Ipam Tools Image
 ---------------------
 To build the ipam-tools image use the following command:
 ```
-make build-binary build-tools-image
+make build-tools-image
 ```
 
 Pushing Plugin/Tools Image to Docker Hub

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,65 +1,37 @@
-Build ipam-driver
-=================
+Building docker-ipam-plugin and docker-ipam-tools images
+========================================================
 
-Prerequisite
-------------
-1. golang development environment is installed (https://golang.org/doc/install)
-
-
-Install Dependency
-------------------
-The driver primarily depends on libnetwork and the infoblox-go-client . They can be installed using the
-following commands:
-
-```
-go get github.com/docker/libnetwork  # libnetwork library (This also pulls down docker engine)
-go get github.com/docker/engine-api  # engine-api library (NOTE: run "make deps" to get dependencies)
-go get github.com/infobloxopen/infoblox-go-client  # Infoblox client
-```
-```engine-api``` is used by the infoblox-ipam driver to obtain the docker
-engine id, which is used to populate the "Tenant ID" EA.
-
-```infoblox-go-client``` is used by the ipam-driver to interact
-with Infoblox.
-
-By default, the ```master``` branch of ```libnetwork``` and ```docker``` will be used. To build
-with release versions, the corresponding release tags need to be checked out. Minimum requirement
-for the ipam-driver is:
-
-```
-libnetwork  0.6
-Docker      1.10.0
-```
-It has also been tested using master. For libnetwork release information, refer to:
-https://github.com/docker/libnetwork/wiki
-
-Obviously, the driver need to be rebuilt after a different version of the above
-is checked out.
-
-Build Executable
-----------------
-A Makefile is provided for automate the build process. To build the ipam-driver, just type
-```make``` in the ```docker-infoblox``` source directory. This creates an executable called ```ipam-driver```.
-
-Build Container Image
+Building Plugin Image
 ---------------------
-To build container image using the Dockerfile in the "docker-infoblox" directory:
-
+To build the plugin image use the following command:
 ```
-make image
+make build-binary build-plugin create-plugin
 ```
 
-Push Container Image to Docker Hub
-----------------------------------
-The Makefile also includes a build target to push the "ipam-driver" container image to your Docker Hub. To do that, you need
-to first setup the following environment variable:
+Building Ipam Tools Image
+---------------------
+To build the ipam-tools image use the following command:
+```
+make build-binary build-tools-image
+```
 
+Pushing Plugin/Tools Image to Docker Hub
+-------------------------------------
+The Makefile also includes a build target to push the plugin image and ipam-tools image to your Docker Hub.
+To do that, you need to first setup the following environment variable:
 ```
 export DOCKERHUB_ID="your-docker-hub-id"
 
 ```
-You can then use the following command to push the "ipam-driver" image to your Docker Hub:
 
+You can then use the following command to push the image to your Docker Hub:
+
+To Push docker-ipam-plugin image
 ```
-make push
+make push-plugin
+```
+
+To Push docker-ipam-plugin image
+```
+make push-tools-image
 ```

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -26,6 +26,21 @@ are based.
 The following additional steps are required:
 - You need to give cloud-api admin user permission to create and modify DNS Views. Instructions on how to add permission to "cloud-api-only" group is included in the video. Follow the same instructions to add "All DNS Views" permission under the "DNS Permissions" Permssion Type.
 
+Configuring Cloud Extensible Attributes using create-ea-defs tool
+-----------------------------------------------------------------
+If the "Cloud Network Automation" license is activated, then the Cloud Extensible Attributes used by the docker-ipam-plugin
+can be defined using the create-ea-defs tool in the infoblox/docker-ipam-tools docker image.
+
+To run create-ea-defs:
+```
+docker run infoblox/docker-ipam-tools create-ea-defs --debug --grid-host 10.120.21.150 --wapi-username=admin --wapi-password=infoblox --wapi-version=2.3
+```
+
+To use the configuration file for create-ea-defs:
+```
+docker run -v /etc/infoblox:/etc/infoblox infoblox/docker-ipam-tools create-ea-defs --debug --conf-file docker-infoblox.conf
+```
+
 Manual Configuration of Cloud Extensible Attributes
 ---------------------------------------------------
 If the "Cloud Network Automation" licensed feature is not activiated, the following Cloud Extensible Attributes must
@@ -37,6 +52,11 @@ be manually defined in Infoblox:
 
 - ```Tenant ID``` - Type: String
 
+- ```Docker-Plugin-Lock``` - Type: String
+
+- ```Docker-Plugin-Lock-Time``` - Type: Integer
+
+
 The User Interface to add Extensible Attribute definitions can be found under the main tab "Administration" and under the
 sub-tab "Extensible Attributes".
 
@@ -47,5 +67,4 @@ Based on the vNIOS configuration, update the following driver configuration:
 - Set grid-host to the management IP address of vNIOS
 - Set username and password to that for the Cloud Admin user on vNIOS.
 
-These configurations can be applied by editing the "run.sh" and "run-container.sh" shell scripts. 
-
+These configurations can be applied by editing the "run.sh" and "run-container.sh" shell scripts.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -41,26 +41,6 @@ To use the configuration file for create-ea-defs:
 docker run -v /etc/infoblox:/etc/infoblox infoblox/docker-ipam-tools create-ea-defs --debug --conf-file docker-infoblox.conf
 ```
 
-Manual Configuration of Cloud Extensible Attributes
----------------------------------------------------
-If the "Cloud Network Automation" licensed feature is not activiated, the following Cloud Extensible Attributes must
-be manually defined in Infoblox:
-
-- ```Cloud API Owned``` - Type: List; Values: True, False
-
-- ```CMP Type``` - Type: String
-
-- ```Tenant ID``` - Type: String
-
-- ```Docker-Plugin-Lock``` - Type: String
-
-- ```Docker-Plugin-Lock-Time``` - Type: Integer
-
-
-The User Interface to add Extensible Attribute definitions can be found under the main tab "Administration" and under the
-sub-tab "Extensible Attributes".
-
-
 IPAM Driver Configuration
 -------------------------
 Based on the vNIOS configuration, update the following driver configuration:


### PR DESCRIPTION
This patch updates the documentation for the usage of
create-ea-defs and also BUILD.md with the instructions
to build the images locally. Also changes the Makefile to fix
Makefile targets.